### PR TITLE
TeamID handling revision

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -140,12 +140,12 @@ func exportCodeSigningFiles(toolName, absExportOutputDirPath string, codeSigning
 		return printFinishedWithError(toolName, "Failed to export Provisioning Profiles, error: %s", err)
 	}
 
-	teamIDs, err := exportedProvProfiles.CollectTeamIDs()
+	provProfileTeamIDs, err := exportedProvProfiles.CollectTeamIDs()
 	if err != nil {
 		return printFinishedWithError(toolName, "Failed to collect Team IDs from Provisioning Profiles, error: %s", err)
 	}
 
-	if err := collectAndExportIdentities(codeSigningSettings, teamIDs, absExportOutputDirPath); err != nil {
+	if err := collectAndExportIdentities(codeSigningSettings, provProfileTeamIDs, absExportOutputDirPath); err != nil {
 		return printFinishedWithError(toolName, "Failed to export identities, error: %s", err)
 	}
 
@@ -311,7 +311,7 @@ func exportProvisioningProfiles(provProfileFileInfos []provprofile.ProvisioningP
 			fmt.Println()
 		}
 		provProfileInfo := aProvProfileFileInfo.ProvisioningProfileInfo
-		teamID, err := provProfileInfo.TeamID()
+		provProfileTeamID, err := provProfileInfo.TeamID()
 		if err != nil {
 			return fmt.Errorf("Invalid Team ID in provisioning profile (uuid: %s), error: %s",
 				provProfileInfo.UUID, err)
@@ -323,7 +323,7 @@ func exportProvisioningProfiles(provProfileFileInfos []provprofile.ProvisioningP
 		log.Infoln("                  Expiration Date:", provProfileInfo.ExpirationDate)
 		log.Infoln("                             UUID:", provProfileInfo.UUID)
 		log.Infoln("                         TeamName:", provProfileInfo.TeamName)
-		log.Infoln("                          Team ID:", teamID)
+		log.Infoln("                          Team ID:", provProfileTeamID)
 
 		exportFileName := provProfileExportFileName(aProvProfileFileInfo)
 		exportPth := filepath.Join(exportTargetDirPath, exportFileName)

--- a/provprofile/provprofile_test.go
+++ b/provprofile/provprofile_test.go
@@ -1,1 +1,130 @@
 package provprofile
+
+import "testing"
+import "github.com/stretchr/testify/require"
+import "github.com/bitrise-io/go-utils/testutil"
+
+func Test_ProvisioningProfileModel_TeamID(t *testing.T) {
+	t.Log("Empty TeamIdentifiers")
+	{
+		provProfile := ProvisioningProfileModel{}
+		teamID, err := provProfile.TeamID()
+		require.EqualError(t, err, "No TeamIdentifier specified")
+		require.Equal(t, "", teamID)
+	}
+
+	t.Log("One TeamIdentifier - valid")
+	{
+		provProfile := ProvisioningProfileModel{
+			TeamIdentifiers: []string{"TeamID1"},
+		}
+		teamID, err := provProfile.TeamID()
+		require.NoError(t, err)
+		require.Equal(t, "TeamID1", teamID)
+	}
+
+	t.Log("One empty TeamIdentifier - invalid")
+	{
+		provProfile := ProvisioningProfileModel{
+			TeamIdentifiers: []string{""},
+		}
+		teamID, err := provProfile.TeamID()
+		require.EqualError(t, err, "An empty item specified for TeamIdentifier")
+		require.Equal(t, "", teamID)
+	}
+
+	t.Log("Two TeamIdentifiers")
+	{
+		provProfile := ProvisioningProfileModel{
+			TeamIdentifiers: []string{
+				"TeamID1", "TeamID2",
+			},
+		}
+		teamID, err := provProfile.TeamID()
+		require.EqualError(t, err, "More than one TeamIdentifier specified")
+		require.Equal(t, "", teamID)
+	}
+}
+
+func Test_ProvisioningProfileFileInfoModels_CollectTeamIDs(t *testing.T) {
+	t.Log("Empty")
+	{
+		ppFileInfos := ProvisioningProfileFileInfoModels{}
+		teamIDs, err := ppFileInfos.CollectTeamIDs()
+		require.NoError(t, err)
+		require.Equal(t, []string{}, teamIDs)
+	}
+
+	t.Log("One item")
+	{
+		ppFileInfos := ProvisioningProfileFileInfoModels{
+			ProvisioningProfileFileInfoModel{
+				ProvisioningProfileInfo: ProvisioningProfileModel{
+					TeamIdentifiers: []string{"TeamID1"},
+				},
+			},
+		}
+		teamIDs, err := ppFileInfos.CollectTeamIDs()
+		require.NoError(t, err)
+		require.Equal(t, []string{"TeamID1"}, teamIDs)
+	}
+
+	t.Log("Two distinct items with different team IDs")
+	{
+		ppFileInfos := ProvisioningProfileFileInfoModels{
+			{
+				ProvisioningProfileInfo: ProvisioningProfileModel{
+					TeamIdentifiers: []string{"TeamID1"},
+				},
+			},
+			{
+				ProvisioningProfileInfo: ProvisioningProfileModel{
+					TeamIdentifiers: []string{"TeamID2"},
+				},
+			},
+		}
+		teamIDs, err := ppFileInfos.CollectTeamIDs()
+		require.NoError(t, err)
+		testutil.EqualSlicesWithoutOrder(t, []string{"TeamID1", "TeamID2"}, teamIDs)
+	}
+
+	t.Log("Two distinct items with same team IDs")
+	{
+		ppFileInfos := ProvisioningProfileFileInfoModels{
+			{
+				ProvisioningProfileInfo: ProvisioningProfileModel{
+					TeamIdentifiers: []string{"TeamID1"},
+				},
+			},
+			{
+				ProvisioningProfileInfo: ProvisioningProfileModel{
+					TeamIdentifiers: []string{"TeamID1"},
+				},
+			},
+		}
+		teamIDs, err := ppFileInfos.CollectTeamIDs()
+		require.NoError(t, err)
+		require.Equal(t, []string{"TeamID1"}, teamIDs)
+	}
+
+	t.Log("Two items, the second one's TeamID is invalid")
+	{
+		ppFileInfos := ProvisioningProfileFileInfoModels{
+			{
+				ProvisioningProfileInfo: ProvisioningProfileModel{
+					UUID:            "UUID1",
+					TeamIdentifiers: []string{"TeamID1"},
+				},
+			},
+			{
+				ProvisioningProfileInfo: ProvisioningProfileModel{
+					UUID:            "UUID2",
+					TeamIdentifiers: []string{""},
+				},
+			},
+		}
+		teamIDs, err := ppFileInfos.CollectTeamIDs()
+		require.EqualError(t, err, "Team ID error for profile (uuid: UUID2), error: An empty item specified for TeamIdentifier")
+		require.Equal(t, []string{}, teamIDs)
+	}
+}


### PR DESCRIPTION
Instead of reading it from `Entitlements` (`com.apple.developer.team-identifier`), read it from the main `TeamIdentifier` array property.

Why: we received a report where a provisioning profile had an array defined for `com.apple.developer.team-identifier` instead of a string. See: https://github.com/bitrise-tools/codesigndoc/issues/28

The only reliable way to read the Team ID from the Provisioning Profile seems to be the `TeamIdentifier` property in the Prov Profile, which is always a single item string array.