### PR TITLE
Include and print the xcodebuild output if scheme scan fails

### DIFF
--- a/xcode/xcodecmd.go
+++ b/xcode/xcodecmd.go
@@ -208,7 +208,7 @@ func (xccmd CommandModel) RunXcodebuildCommand(xcodebuildActionArgs ...string) (
 func (xccmd CommandModel) ScanSchemes() ([]string, error) {
 	xcoutput, err := xccmd.RunXcodebuildCommand("-list")
 	if err != nil {
-		return []string{}, err
+		return []string{}, fmt.Errorf("error: %s | xcodebuild output: %s", err, xcoutput)
 	}
 
 	parsedSchemes := parseSchemesFromXcodeOutput(xcoutput)


### PR DESCRIPTION
Fixing https://github.com/bitrise-tools/codesigndoc/issues/31