### PR TITLE
Add 3 Xs (XXX) to the mktemp command argument

### DIFF
--- a/_scripts/install_wrap.sh
+++ b/_scripts/install_wrap.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo " => Creating a temporary directory for codesigndoc ..."
-temp_dir="$(mktemp -d -t codesigndocXXX)"
+temp_dir="$(mktemp -d -t codesigndoc)"
 codesigndoc_bin_path="${temp_dir}/codesigndoc"
 
 version_to_use="0.9.18"

--- a/_scripts/install_wrap.sh
+++ b/_scripts/install_wrap.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo " => Creating a temporary directory for codesigndoc ..."
-temp_dir="$(mktemp -d -t codesigndoc)"
+temp_dir="$(mktemp -d -t codesigndocXXX)"
 codesigndoc_bin_path="${temp_dir}/codesigndoc"
 
 version_to_use="0.9.18"

--- a/_scripts/install_wrap.sh.template
+++ b/_scripts/install_wrap.sh.template
@@ -2,7 +2,7 @@
 set -e
 
 echo " => Creating a temporary directory for codesigndoc ..."
-temp_dir="$(mktemp -d -t codesigndoc)"
+temp_dir="$(mktemp -d -t codesigndocXXXXXX)"
 codesigndoc_bin_path="${temp_dir}/codesigndoc"
 
 version_to_use="{{version}}"


### PR DESCRIPTION
To fix the following error:

    mktemp: too few X's in template ‘codesigndoc’