### PR TITLE
new xcode command flag: `xcodebuild-sdk`

### DIFF
--- a/cmd/xcode.go
+++ b/cmd/xcode.go
@@ -28,6 +28,7 @@ var (
 	paramXcodeProjectFilePath        = ""
 	paramXcodeScheme                 = ""
 	paramXcodebuildOutputLogFilePath = ""
+	paramXcodebuildSDK               = ""
 )
 
 func init() {
@@ -42,6 +43,9 @@ func init() {
 	xcodeCmd.Flags().StringVar(&paramXcodebuildOutputLogFilePath,
 		"xcodebuild-log", "",
 		"xcodebuild output log (file path). If specified it will be used instead of running xcodebuild")
+	xcodeCmd.Flags().StringVar(&paramXcodebuildSDK,
+		"xcodebuild-sdk", "",
+		"xcodebuild -sdk param. If a value is specified for this flag it'll be passed to xcodebuild as the value of the -sdk flag. For more info about the values please see xcodebuild's -sdk flag docs. Example value: iphoneos")
 }
 
 func printXcodeScanFinishedWithError(format string, args ...interface{}) error {
@@ -110,6 +114,10 @@ func scanXcodeProject(cmd *cobra.Command, args []string) error {
 			schemeToUse = selectedScheme
 		}
 		xcodeCmd.Scheme = schemeToUse
+
+		if paramXcodebuildSDK != "" {
+			xcodeCmd.SDK = paramXcodebuildSDK
+		}
 
 		fmt.Println()
 		fmt.Println()

--- a/xcode/xcodecmd.go
+++ b/xcode/xcodecmd.go
@@ -20,10 +20,25 @@ import (
 
 // CommandModel ...
 type CommandModel struct {
+	// --- Required ---
+
 	// ProjectFilePath - might be a `xcodeproj` or `xcworkspace`
-	ProjectFilePath  string
-	Scheme           string
+	ProjectFilePath string
+
+	// --- Optional ---
+
+	// Scheme will be passed to xcodebuild as the -scheme flag's value
+	// Only passed to xcodebuild if not empty!
+	Scheme string
+
+	// CodeSignIdentity will be passed to xcodebuild as an CODE_SIGN_IDENTITY= argument.
+	// Only passed to xcodebuild if not empty!
 	CodeSignIdentity string
+
+	// SDK: if defined it'll be passed as the -sdk flag to xcodebuild.
+	// For more info about the possible values please see xcodebuild's docs about the -sdk flag.
+	// Only passed to xcodebuild if not empty!
+	SDK string
 }
 
 func parseSchemesFromXcodeOutput(xcodeOutput string) []string {
@@ -178,6 +193,10 @@ func (xccmd CommandModel) transformToXcodebuildParams(xcodebuildActionArgs ...st
 	baseArgs := []string{projParam, xccmd.ProjectFilePath}
 	if xccmd.Scheme != "" {
 		baseArgs = append(baseArgs, "-scheme", xccmd.Scheme)
+	}
+
+	if xccmd.SDK != "" {
+		baseArgs = append(baseArgs, "-sdk", xccmd.SDK)
 	}
 
 	if xccmd.CodeSignIdentity != "" {


### PR DESCRIPTION
if specified the value will be passed as the `-sdk` flag's value to `xcodebuild` for the scan

Related issue / feature request: https://github.com/bitrise-tools/codesigndoc/issues/41