### PR TITLE
Error log updated for:

### DIFF
--- a/codesigndoc/codesigndoc.go
+++ b/codesigndoc/codesigndoc.go
@@ -1,9 +1,10 @@
 package codesigndoc
 
 import (
-	"errors"
 	"fmt"
 	"os"
+
+	"github.com/bitrise-io/go-utils/colorstring"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/log"
@@ -72,7 +73,10 @@ func ExportCodesignFiles(archivePath, outputDirPath string, certificatesOnly boo
 		}
 
 		if len(ipaExportCodeSignGroups) == 0 {
-			return false, false, errors.New("no ipa export code sign groups collected")
+			errorString := "\n🚨  " + colorstring.Red("Failed to collect codesigning files for the selected distribution type.\n") +
+				colorstring.Yellow("Export an ipa with the same export method which code signing files you want to collect (e.g app-store if you want to collect the code signing files for app-store distribution) in your local xcode and run codesigndoc again.\n") +
+				colorstring.Yellow("If the tool fails please report the issue with the codesigndoc log and the local ipa exportOptions.plist")
+			return false, false, fmt.Errorf(colorstring.Yellow(errorString))
 		}
 
 		codeSignGroups := append(ipaExportCodeSignGroups, archiveCodeSignGroup)

--- a/codesigndoc/codesigngroup.go
+++ b/codesigndoc/codesigngroup.go
@@ -184,7 +184,8 @@ func collectIpaExportCodeSignGroups(archive xcarchive.IosArchive, installedCerti
 
 		if len(filteredCodeSignGroups) == 0 {
 			fmt.Println()
-			log.Errorf(collectCodesigningFilesInfo)
+			log.Errorf("🚨  Could not find any valid code signing file for the selected export method:")
+			log.Warnf(collectCodesigningFilesInfo)
 			fmt.Println()
 			fmt.Println()
 			question := "Do you want to collect another ipa export code sign files"


### PR DESCRIPTION
"If the xcode archive is success, we have the archive required codesigning files. Then codesigndoc asks for the distribution method, if method selected, which codesigning files are not exist on the developer's machine it mentions the fail, and asks if do you want to export other files? If no selected it finishes with strange error: no ipa export code sign groups collected"