### PR TITLE
Log update

### DIFF
--- a/bitriseio/bitriseio.go
+++ b/bitriseio/bitriseio.go
@@ -17,7 +17,7 @@ import (
 )
 
 // UploadCodesigningFiles ...
-func UploadCodesigningFiles(certificates []certificateutil.CertificateInfoModel, profiles []profileutil.ProvisioningProfileInfoModel, outputDirPath string) (bool, bool, error) {
+func UploadCodesigningFiles(certificates []certificateutil.CertificateInfoModel, profiles []profileutil.ProvisioningProfileInfoModel, certsOnly bool, outputDirPath string) (bool, bool, error) {
 	accessToken, err := askAccessToken()
 	if err != nil {
 		return false, false, err
@@ -35,9 +35,12 @@ func UploadCodesigningFiles(certificates []certificateutil.CertificateInfoModel,
 
 	bitriseClient.SetSelectedAppSlug(selectedAppSlug)
 
-	provProfilesUploaded, err := uploadExportedProvProfiles(bitriseClient, profiles, outputDirPath)
-	if err != nil {
-		return false, false, err
+	var provProfilesUploaded bool
+	if !certsOnly {
+		provProfilesUploaded, err = uploadExportedProvProfiles(bitriseClient, profiles, outputDirPath)
+		if err != nil {
+			return false, false, err
+		}
 	}
 
 	certsUploaded, err := uploadExportedIdentity(bitriseClient, certificates, outputDirPath)

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -65,5 +65,8 @@ func printFinished(provProfilesUploaded bool, certsUploaded bool) {
 	if !provProfilesUploaded && !certsUploaded {
 		log.Warnf("You just have to upload the found certificates (.p12) and provisioning profiles (.mobileprovision) and you'll be good to go!")
 		fmt.Println()
+	} else if !certsUploaded {
+		log.Warnf("You just have to upload the found certificates (.p12) and you'll be good to go!")
+		fmt.Println()
 	}
 }

--- a/cmd/xcode.go
+++ b/cmd/xcode.go
@@ -83,9 +83,7 @@ func scanXcodeProject(cmd *cobra.Command, args []string) error {
 	if projectPath == "" {
 		askText := `Please drag-and-drop your Xcode Project (` + colorstring.Green(".xcodeproj") + `) or Workspace (` + colorstring.Green(".xcworkspace") + `) file, 
 the one you usually open in Xcode, then hit Enter.
-
 (Note: if you have a Workspace file you should most likely use that)`
-		fmt.Println()
 		projpth, err := goinp.AskForPath(askText)
 		if err != nil {
 			return fmt.Errorf("failed to read input: %s", err)
@@ -127,7 +125,6 @@ the one you usually open in Xcode, then hit Enter.
 		xcodeCmd.SDK = paramXcodebuildSDK
 	}
 
-	fmt.Println()
 	fmt.Println()
 	log.Printf("🔦  Running an Xcode Archive, to get all the required code signing settings...")
 	archivePath, buildLog, err := xcodeCmd.GenerateArchive()

--- a/codesigndoc/codesigndoc.go
+++ b/codesigndoc/codesigndoc.go
@@ -87,18 +87,24 @@ func ExportCodesignFiles(archivePath, outputDirPath string, certificatesOnly boo
 	provProfilesUploaded := (len(profilesToExport) == 0)
 	certsUploaded := (len(certificatesToExport) == 0)
 
-	if len(profilesToExport) > 0 || len(certificatesToExport) > 0 {
+	var shouldUpload bool
+	if !certificatesOnly {
 		fmt.Println()
-		shouldUpload, err := goinp.AskForBoolFromReader("Do you want to upload the provisioning profiles and certificates to Bitrise?", os.Stdin)
+		shouldUpload, err = goinp.AskForBoolFromReader("Do you want to upload the provisioning profiles and certificates to Bitrise?", os.Stdin)
 		if err != nil {
 			return false, false, err
 		}
+	} else {
+		shouldUpload, err = goinp.AskForBoolFromReader("Do you want to upload the certificates to Bitrise?", os.Stdin)
+		if err != nil {
+			return false, false, err
+		}
+	}
 
-		if shouldUpload {
-			certsUploaded, provProfilesUploaded, err = bitriseio.UploadCodesigningFiles(certificatesToExport, profilesToExport, outputDirPath)
-			if err != nil {
-				return false, false, err
-			}
+	if shouldUpload {
+		certsUploaded, provProfilesUploaded, err = bitriseio.UploadCodesigningFiles(certificatesToExport, profilesToExport, certificatesOnly, outputDirPath)
+		if err != nil {
+			return false, false, err
 		}
 	}
 

--- a/codesigndoc/codesigngroup.go
+++ b/codesigndoc/codesigngroup.go
@@ -75,9 +75,6 @@ func printCodesignGroup(group export.CodeSignGroup) {
 
 // collectExportCertificate returns the certificate to use for the ipa export
 func collectExportCertificate(isMacArchive bool, archiveCertificate certificateutil.CertificateInfoModel, installedCertificates []certificateutil.CertificateInfoModel, installedInstallerCertificates []certificateutil.CertificateInfoModel) ([]certificateutil.CertificateInfoModel, error) {
-	fmt.Println()
-	fmt.Println()
-
 	var selectedCertificates []certificateutil.CertificateInfoModel
 
 	// Export method
@@ -91,12 +88,12 @@ func collectExportCertificate(isMacArchive bool, archiveCertificate certificateu
 
 	// Asking the user over and over until we find a valid certificate for the selected export method.
 	for searchingValidCertificate := true; searchingValidCertificate; {
-
 		fmt.Println()
 		selectedExportMethod, err := goinp.SelectFromStringsWithDefault("Select the ipa export method", 1, exportMethods)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read input: %s", err)
 		}
+
 		log.Debugf("selected export method: %v", selectedExportMethod)
 
 		selectedCertificates, err = filterCertificates(isMacArchive, selectedExportMethod, "", selectedCertificates, archiveCertificate, installedCertificates, installedInstallerCertificates)
@@ -105,7 +102,7 @@ func collectExportCertificate(isMacArchive bool, archiveCertificate certificateu
 		}
 
 		fmt.Println()
-		question := `Do you want to collect another certificate? [yes,no]`
+		question := `Do you want to collect another certificate?`
 		searchingValidCertificate, err = goinp.AskForBoolWithDefault(question, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read input: %s", err)
@@ -161,6 +158,8 @@ func filterCertificates(isMacArchive bool, selectedExportMethod, selectedTeam st
 		// Skip it if only 1 team has certificates on the machine. Or the archiving team does'n have the desired certificate type.
 		// Skip the question + set the useArchiveTeam = false, if multiple team has certificate for the export method but the archiving team is not one of them.
 		if len(filteredCertificatesByTeam) > 1 && contains {
+			fmt.Println()
+
 			question := fmt.Sprintf(`The archive used codesigning files of team: %s - %s
 Would you like to use this team to export an ipa file?`, archiveCertificate.TeamID, archiveCertificate.TeamName)
 			useArchiveTeam, err = goinp.AskForBoolWithDefault(question, true)
@@ -280,7 +279,6 @@ func collectExportCodeSignGroups(archive Archive, installedCertificates []certif
 	}
 
 	for true {
-		fmt.Println()
 		selectedExportMethod, err := goinp.SelectFromStringsWithDefault("Select the ipa export method", 1, exportMethods)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read input: %s", err)
@@ -301,7 +299,6 @@ func collectExportCodeSignGroups(archive Archive, installedCertificates []certif
 		if len(filteredCodeSignGroups) == 0 {
 			fmt.Println()
 			log.Errorf(collectCodesigningFilesInfo)
-			fmt.Println()
 			fmt.Println()
 			question := "Do you want to collect another ipa export code sign files"
 			question += "\n(select NO to finish collecting codesign files and continue)"
@@ -333,7 +330,6 @@ func collectExportCodeSignGroups(archive Archive, installedCertificates []certif
 		} else {
 			sort.Strings(certificateOptions)
 
-			fmt.Println()
 			question := fmt.Sprintf("Select the Codesign Indentity for %s ipa export", selectedExportMethod)
 			selectedCertificateOption, err = goinp.SelectFromStringsWithDefault(question, 1, certificateOptions)
 			if err != nil {
@@ -435,14 +431,11 @@ func collectExportCodeSignGroups(archive Archive, installedCertificates []certif
 		}
 
 		fmt.Println()
-		fmt.Println()
 		log.Infof("Codesign settings will be used for %s .ipa/.app export:", exportMethod(collectedCodeSignGroup))
-		fmt.Println()
 		printCodesignGroup(collectedCodeSignGroup)
 
 		collectedCodeSignGroups = append(collectedCodeSignGroups, collectedCodeSignGroup)
 
-		fmt.Println()
 		fmt.Println()
 		question := "Do you want to collect another ipa export code sign files"
 		question += "\n(select NO to finish collecting codesign files and continue)"
@@ -463,9 +456,7 @@ func collectExportSelectableCodeSignGroups(archive Archive, installedCertificate
 	bundleIDEntitlemenstMap := archive.BundleIDEntitlementsMap()
 
 	fmt.Println()
-	fmt.Println()
 	log.Infof("Targets to sign:")
-	fmt.Println()
 	for bundleID, entitlements := range bundleIDEntitlemenstMap {
 		fmt.Printf("- %s with %d capabilities\n", bundleID, len(entitlements))
 	}
@@ -597,7 +588,6 @@ func getCodeSignGroup(archive Archive, installedCertificates []certificateutil.C
 
 	fmt.Println()
 	log.Infof("Codesign settings used for archive:")
-	fmt.Println()
 	printCodesignGroup(archiveCodeSignGroup)
 
 	return archiveCodeSignGroup, nil

--- a/codesigndoc/export.go
+++ b/codesigndoc/export.go
@@ -21,14 +21,12 @@ func collectAndExportIdentities(certificates []certificateutil.CertificateInfoMo
 	fmt.Println()
 	fmt.Println()
 	log.Infof("Required Identities/Certificates (%d)", len(certificates))
-	fmt.Println()
 	for _, certificate := range certificates {
 		log.Printf("- %s", certificate.CommonName)
 	}
 
 	fmt.Println()
 	log.Infof("Exporting the Identities (Certificates):")
-	fmt.Println()
 
 	identitiesWithKeychainRefs := []osxkeychain.IdentityWithRefModel{}
 	defer osxkeychain.ReleaseIdentityWithRefList(identitiesWithKeychainRefs)
@@ -80,16 +78,13 @@ func collectAndExportProvisioningProfiles(profiles []profileutil.ProvisioningPro
 		return nil
 	}
 
-	fmt.Println()
 	log.Infof("Required Provisioning Profiles (%d)", len(profiles))
-	fmt.Println()
 	for _, profile := range profiles {
 		log.Printf("- %s (UUID: %s)", profile.Name, profile.UUID)
 	}
 
 	fmt.Println()
 	log.Infof("Exporting Provisioning Profiles...")
-	fmt.Println()
 
 	for _, profile := range profiles {
 		log.Printf("searching for required Provisioning Profile: %s (UUID: %s)", profile.Name, profile.UUID)


### PR DESCRIPTION
And the codesigndoc will not ask about the Provisioning Profiles in `--certs-only` mode.

Please check the logs for the followings:
 - Scan for Prov. Profiles and Certs. - And upload them.
 - Scan for Prov. Profiles and Certs. - And **don't** upload them.

----

- Scan for Certs only (--certs-only). - And upload them.
- Scan for Certs only (--certs-only). - And **don't** upload them.