### PR TITLE
xamarin: Auto scan directory for project files

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -14,6 +14,9 @@ const (
 	// iOS
 	xcodeWorkspace ProjectType = "*.xcworkspace"
 	xcodeProject   ProjectType = "*.xcodeproj"
+
+	// Xamarin
+	xamarinSolution ProjectType = "*.sln"
 )
 
 // Scans the root dir for the provided project files

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ProjectType ...
+type ProjectType string
+
+const (
+	// iOS
+	xcodeWorkspace ProjectType = "*.xcworkspace"
+	xcodeProject   ProjectType = "*.xcodeproj"
+)
+
+// Scans the root dir for the provided project files
+// If none of them in the root dir, then it will return an error
+func scanForProjectFiles(projectFiles []ProjectType) (string, error) {
+	root, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for _, projectFile := range projectFiles {
+		pathPattern := filepath.Join(root, string(projectFile))
+		paths, err := filepath.Glob(pathPattern)
+		if err != nil {
+			return "", err
+		}
+
+		switch len(paths) {
+		case 0:
+			continue
+		case 1:
+			return paths[0], nil
+		default:
+			return "", fmt.Errorf("multiple project file (%s) found in the root (%s) directory: %s", projectFile, root, strings.Join(paths, "\n"))
+		}
+	}
+
+	return "", fmt.Errorf("no project file found: %s", root)
+
+}

--- a/cmd/xamarin.go
+++ b/cmd/xamarin.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 	"path/filepath"
 	"sort"
 
@@ -87,13 +88,25 @@ func scanXamarinProject(cmd *cobra.Command, args []string) error {
 	// Xamarin Solution Path
 	xamarinCmd.SolutionFilePath = paramXamarinSolutionFilePath
 	if xamarinCmd.SolutionFilePath == "" {
-		askText := `Please drag-and-drop your Xamarin Solution (` + colorstring.Green(".sln") + `) file,
-and then hit Enter`
+
 		fmt.Println()
-		projpth, err := goinp.AskForPath(askText)
+		log.Infof("Scan the directory for project files")
+		projpth, err := scanForProjectFiles([]ProjectType{xamarinSolution})
 		if err != nil {
-			return fmt.Errorf("failed to read input: %s", err)
+			log.Printf("Failed: %s", err)
+			fmt.Println()
+
+			log.Infof("Provide the project file manually")
+			askText := `Please drag-and-drop your Xamarin Solution (` + colorstring.Green(".sln") + `) file,
+and then hit Enter`
+			projpth, err = goinp.AskForPath(askText)
+			if err != nil {
+				return fmt.Errorf("failed to read input: %s", err)
+			}
+		} else {
+			log.Printf("Found one project file: %s.", path.Base(projpth))
 		}
+
 		xamarinCmd.SolutionFilePath = projpth
 	}
 	log.Debugf("xamSolutionPth: %s", xamarinCmd.SolutionFilePath)

--- a/cmd/xcode.go
+++ b/cmd/xcode.go
@@ -84,7 +84,7 @@ func scanXcodeProject(cmd *cobra.Command, args []string) error {
 	if projectPath == "" {
 
 		log.Infof("Scan the directory for project files")
-		projpth, err := scanForProjectFiles()
+		projpth, err := scanForProjectFiles([]ProjectType{xcodeWorkspace, xcodeProject})
 		if err != nil {
 			log.Printf("Failed: %s", err)
 			fmt.Println()
@@ -167,47 +167,4 @@ the one you usually open in Xcode, then hit Enter.
 
 	printFinished(provProfilesUploaded, certsUploaded)
 	return nil
-}
-
-// Scans the root dir for project files
-// If there is a .xcworkspace file in the root dir it will return it's paths
-// If there is a .xcodeproject file in the root dir it will return it's paths
-// If none of them in the root dir, then it will return an error
-func scanForProjectFiles() (string, error) {
-	root, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	workspacePattern := filepath.Join(root, "*.xcworkspace")
-	workspacePaths, err := filepath.Glob(workspacePattern)
-	if err != nil {
-		return "", err
-	}
-
-	switch len(workspacePaths) {
-	case 0:
-		// Search for .xcodeproj
-		break
-	case 1:
-		return workspacePaths[0], nil
-	default:
-		return "", fmt.Errorf("multiple .xcworkspace files found in the root (%s), directory: %s", root, strings.Join(workspacePaths, "\n"))
-	}
-
-	projectPattern := filepath.Join(root, "*.xcodeproj")
-	projectPaths, err := filepath.Glob(projectPattern)
-	if err != nil {
-		return "", err
-	}
-
-	switch len(projectPaths) {
-	case 0:
-		return "", fmt.Errorf("no .xcworkspace or .xcodeproject file found in directory: %s", root)
-	case 1:
-		return projectPaths[0], nil
-	default:
-		return "", fmt.Errorf("multiple .xcworkspace files found in the root (%s), directory: %s", root, strings.Join(workspacePaths, "\n"))
-	}
-
 }

--- a/cmd/xcode.go
+++ b/cmd/xcode.go
@@ -172,7 +172,7 @@ the one you usually open in Xcode, then hit Enter.
 // Scans the root dir for project files
 // If there is a .xcworkspace file in the root dir it will return it's paths
 // If there is a .xcodeproject file in the root dir it will return it's paths
-// If non of them in the root dir, then it will return an error
+// If none of them in the root dir, then it will return an error
 func scanForProjectFiles() (string, error) {
 	root, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
**Dependent PR:**
Merge this first:
https://github.com/bitrise-tools/codesigndoc/pull/95

**Decription:**
Add the automatic scan feature to the codesigndoc.
The tool should check the root directory for the project files (e.g: .sln). If it've found one it should scan that. If it could not find any, then it should roll back to the current 'drag-and-drop' solution.

For Xamarin: 
If the tool find .sln,  it should scan the .sln

---

If no project path was added as a flag:
1) Scans the directory for project files:
    https://github.com/bitrise-tools/codesigndoc/pull/96/files#diff-35224a40569654c782dc6a09e69db2b1R93

    https://github.com/bitrise-tools/codesigndoc/pull/96/files#diff-b4695c7b6902e27273329af6261b0c73R25
    If it finds one, it will use it for the scanner.

2) If there are no project files in the directory (or there is multiple one), ask the user to provide it manually:
https://github.com/bitrise-tools/codesigndoc/pull/96/files#diff-35224a40569654c782dc6a09e69db2b1R96

---

**How to test it:**
1) Scanner should find the project
Run the `go run *.go scan xamarin` command from an Xamarin project's directory

2) User needs to provide the project file manually
Run the `go run *.go scan xamarin` command from a directory where is no Xamarin project.