### PR TITLE
Glob path fix

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -92,7 +92,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c5ac1b062ba1470ca0901d2272624bd59d42042f15e92c8d0b15b5711a123d64"
+  digest = "1:241f153676f6090e307e6858d11d71f1d61d48bdf666718db1f116e325e7d3ba"
   name = "github.com/bitrise-tools/go-xcode"
   packages = [
     "certificateutil",
@@ -106,7 +106,7 @@
     "xcodeproj",
   ]
   pruneopts = "UT"
-  revision = "8e44ecb550c0cadef602edda92e5c10476dd5daa"
+  revision = "b3f7172f910693d60973a07b61db757aca81f778"
 
 [[projects]]
   branch = "master"

--- a/codesigndocuitests/iostestrunner.go
+++ b/codesigndocuitests/iostestrunner.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-tools/go-xcode/plistutil"
 	"github.com/bitrise-tools/go-xcode/profileutil"
+	"github.com/bitrise-tools/go-xcode/utility"
 )
 
 // IOSTestRunner ...
@@ -21,7 +22,7 @@ type IOSTestRunner struct {
 
 // NewIOSTestRunners is the *-Runner.app which is generated with the xcodebuild build-for-testing command
 func NewIOSTestRunners(path string) ([]*IOSTestRunner, error) {
-	runnerPattern := filepath.Join(path, "*-Runner.app")
+	runnerPattern := filepath.Join(utility.EscapeGlobPath(path), "*-Runner.app")
 	possibleTestRunnerPths, err := filepath.Glob(runnerPattern)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/bitrise-tools/go-xcode/profileutil/util.go
+++ b/vendor/github.com/bitrise-tools/go-xcode/profileutil/util.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-tools/go-xcode/utility"
 	"github.com/fullsailor/pkcs7"
 )
 
@@ -46,7 +47,7 @@ func InstalledProvisioningProfiles(profileType ProfileType) ([]*pkcs7.PKCS7, err
 		return nil, err
 	}
 
-	pattern := filepath.Join(absProvProfileDirPath, "*"+ext)
+	pattern := filepath.Join(utility.EscapeGlobPath(absProvProfileDirPath), "*"+ext)
 	pths, err := filepath.Glob(pattern)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/bitrise-tools/go-xcode/utility/glob.go
+++ b/vendor/github.com/bitrise-tools/go-xcode/utility/glob.go
@@ -1,0 +1,13 @@
+package utility
+
+// EscapeGlobPath escapes a partial path, determined at runtime, used as a parameter for filepath.Glob
+func EscapeGlobPath(path string) string {
+	var escaped string
+	for _, ch := range path {
+		if ch == '[' || ch == ']' || ch == '-' || ch == '*' || ch == '?' || ch == '\\' {
+			escaped += "\\"
+		}
+		escaped += string(ch)
+	}
+	return escaped
+}

--- a/vendor/github.com/bitrise-tools/go-xcode/xcarchive/macos.go
+++ b/vendor/github.com/bitrise-tools/go-xcode/xcarchive/macos.go
@@ -109,7 +109,7 @@ func NewMacosApplication(path string) (MacosApplication, error) {
 
 	extensions := []MacosExtension{}
 	{
-		pattern := filepath.Join(path, "Contents/PlugIns/*.appex")
+		pattern := filepath.Join(utility.EscapeGlobPath(path), "Contents/PlugIns/*.appex")
 		pths, err := filepath.Glob(pattern)
 		if err != nil {
 			return MacosApplication{}, fmt.Errorf("failed to search for watch application's extensions using pattern: %s, error: %s", pattern, err)
@@ -156,7 +156,7 @@ func NewMacosArchive(path string) (MacosArchive, error) {
 
 	application := MacosApplication{}
 	{
-		pattern := filepath.Join(path, "Products/Applications/*.app")
+		pattern := filepath.Join(utility.EscapeGlobPath(path), "Products/Applications/*.app")
 		pths, err := filepath.Glob(pattern)
 		if err != nil {
 			return MacosArchive{}, err


### PR DESCRIPTION
Description:
Codesigndoc failes - if the used Xcode project scheme conatins characters `[` and `]`  used as control characters in a regexp pattern, with issue: 
```
failed to analyze archive, error: failed to find main app, using pattern: 
/var/folders/5k/s091mx790jj0j2g9w3rxsdgm0000gn/T/__codesigndoc__464040371/[Copy] xcode 10 
.xcarchive/Products/Applications/*.app
```

----

- Fix the xcode scanner:
    - Dep update (go-xcode)

- Fix the xcodeuitests scanner:
    - Implement the EscapeGlobPath util for the UITest target search.